### PR TITLE
Issue-2 - Don't silently fail when the surveyedBy node is missing

### DIFF
--- a/1_ElectronicFieldNotes.py
+++ b/1_ElectronicFieldNotes.py
@@ -81,7 +81,7 @@ if 0:
 
 ##mode = "DEBUG"
 mode = "PRODUCTION"
-EHSN_VERSION = "v1.3.1"
+EHSN_VERSION = "v1.3.2"
 eHSN_WINDOW_SIZE = (965, 730)
 
 # import wx.lib.inspection

--- a/XMLManager.py
+++ b/XMLManager.py
@@ -2100,8 +2100,11 @@ def LevelChecksFromXML(LevelChecks, waterLevelRunManager):
     comments = LevelChecks.find('comments').text
     waterLevelRunManager.commentsCtrl = "" if comments is None else comments
 
-    surveyedby = LevelChecks.find('surveyedby').text
-    waterLevelRunManager.surveyedbyCtrl = "" if surveyedby is None else surveyedby
+    try:
+        surveyedby = LevelChecks.find('surveyedby').text
+        waterLevelRunManager.surveyedbyCtrl = "" if surveyedby is None else surveyedby
+    except:
+        waterLevelRunManager.surveyedbyCtrl = ""
 
     try:
         loggerName = LevelChecks.find('loggerName').text


### PR DESCRIPTION
Bumped the version number too, since v1.3.1 should not be released to the field.