### PR TITLE
Issue-14 - Pull the version upgrade message file from GitHub, instead from an FTP site

### DIFF
--- a/1_ElectronicFieldNotes.py
+++ b/1_ElectronicFieldNotes.py
@@ -81,7 +81,7 @@ if 0:
 
 ##mode = "DEBUG"
 mode = "PRODUCTION"
-EHSN_VERSION = "v1.3.2"
+EHSN_VERSION = "v1.3.3"
 eHSN_WINDOW_SIZE = (965, 730)
 
 # import wx.lib.inspection

--- a/VersionCheck.py
+++ b/VersionCheck.py
@@ -1,11 +1,11 @@
 # All works in this code have been curated by ECCC and licensed under the GNU General Public License v3.0. 
 # Read more: https://www.gnu.org/licenses/gpl-3.0.en.html
 
-from ftplib import FTP
 import wx
 import wx.lib.agw.genericmessagedialog as GMD
 import sys
 import os
+import requests
 
 def Check(version, parent, alwaysShow):
     # myVersion = "v1.1.4"
@@ -24,36 +24,17 @@ def Check(version, parent, alwaysShow):
 
 
     try:
-        ftp = FTP('nais.ec.gc.ca')
-        print ftp.login('wsctradesite', 'WSCtrade123')
+        message_url = "https://raw.githubusercontent.com/ECCC-MSC/WSC-EHSN/master/message"
+        response = requests.get(message_url)
+        response.raise_for_status()
+        msg = response.content.decode('Windows-1252')  # TODO: Consider encoding the message file as UTF-8
 
-        
-
-
-        ftp.cwd('WSC eHSN')
-        print "======================================"
-        ftp.retrlines('LIST')
-        fdir = 'message'
-        f = open(fdir,'wb')
-
-        ftp.retrbinary('RETR message.txt', f.write)
-        f.close()
-
-        f = open(fdir,'r')
-
-        for index, line in enumerate(f):
-            print '%s\t%s' % (index, line),
-            if index == 0:
-                currentVersion = line[1:]
-            elif index == 1:
-                rank = int(line)
-            else:
-                if isinstance(line, str):
-                    line = line.decode('latin-1')
-                msg += unicode(line)
+        print msg
         print ""
-        f.close()
-        os.remove(fdir)
+
+        lines = msg.splitlines()
+        currentVersion = lines[0][1:]
+        rank = int(lines[1])
 
         myVersions = myVersion[1:].split('.')
         currentVersions = currentVersion.split('.')


### PR DESCRIPTION
@DougStiff This fixes a security bug. The FTP credentials were hard-coded into the source code, and have essential been publicly broadcast on GitHub for over a year. I was able to use these credentials to connect to the WSC FTP site and create a file in your personal folder.

ftp://wsctradesite@nais.ec.gc.ca/Doug/DougSchmidtWasHereUsingPubliclyAvailabledCredentials.txt

So WSC should probably immediately consider the 'wsctradesite' FTP credentials to be compromised. To limit the exposure, you might want to consider giving that account much less wide-reaching permissions. Ideally, the `wsctradesite` account should only need to be able to read the `WSC eHSN\message.txt` file from this FTP site. That account should not be able to read from other folders, and should not be allowed to write to anything on the FTP server.

This code change will make the EHSN app pull its version upgrade message from GitHub, rather than requiring a set of hard-coded FTP credentials (which are now compromised). So the workflow change would be that to get a new message shown to the eHSN user base, someone would just need to change the [message](https://github.com/ECCC-MSC/WSC-EHSN/blob/master/message) file on the master branch of the repo.

No GitHub credentials are required to retrieve the file using the super-robust GitHub CDN.

Once this new version of the eHSN app has been deployed to all your users, you can fully delete the `wsctradesite` FTP account. If any old eHSN apps try to do a version check, they'll just start seeing a "Check for updates failed" message box.