### PR TITLE
Fixed autosave date, removed FV package legend, added function call to menu, and fixed resize issue

### DIFF
--- a/AttachPhotoBox.py
+++ b/AttachPhotoBox.py
@@ -20,7 +20,7 @@ class AttachPhotoBox(scrolled.ScrolledPanel):
         self.browseList = []
         self.columnList = []
         self.typeList = []
-        self.type = ["SIT", "STR", "COL", "CBL", "EQP", "CDT", "HSN"]
+        self.type = ["Site", "Structures, Site Facilities", "Control Conditions", "Cableway", "Device", "Device Conditions", "Hydrometric Survey Note"]
         self.rootPath = os.path.dirname(os.path.realpath(sys.argv[0]))
 
         self.InitUI()
@@ -36,7 +36,7 @@ class AttachPhotoBox(scrolled.ScrolledPanel):
 
         self.buttonList.append(wx.Button(self, label="-", size=self.buttonSize))
         self.typeList.append(wx.ComboBox(self, style=wx.CB_DROPDOWN|wx.TE_READONLY, choices=self.type))
-        self.typeList[-1].SetValue("SIT")
+        self.typeList[-1].SetValue("Site")
         self.addrList.append(wx.TextCtrl(self, size=self.barSize))
         self.browseList.append(wx.Button(self, label="Browse", size=self.browseSize))
 
@@ -62,7 +62,7 @@ class AttachPhotoBox(scrolled.ScrolledPanel):
         self.columnList.append(wx.BoxSizer(wx.HORIZONTAL))
         self.buttonList.append(wx.Button(self, label="-", size=self.buttonSize))
         self.typeList.append(wx.ComboBox(self, style=wx.CB_DROPDOWN | wx.TE_READONLY, choices=self.type))
-        self.typeList[-1].SetValue("SIT")
+        self.typeList[-1].SetValue("Site")
         self.addrList.append(wx.TextCtrl(self, size=self.barSize))
         self.browseList.append(wx.Button(self, label="Browse", size=self.browseSize))
 
@@ -82,7 +82,7 @@ class AttachPhotoBox(scrolled.ScrolledPanel):
             self.columnList.append(wx.BoxSizer(wx.HORIZONTAL))
             self.buttonList.append(wx.Button(self, label="-", size=self.buttonSize))
             self.typeList.append(wx.ComboBox(self, style=wx.CB_DROPDOWN | wx.TE_READONLY, choices=self.type))
-            self.typeList[-1].SetValue("SIT")
+            self.typeList[-1].SetValue("Site")
             self.addrList.append(wx.TextCtrl(self, size=self.barSize))
             self.browseList.append(wx.Button(self, label="Browse", size=self.browseSize))
 
@@ -141,49 +141,49 @@ class AttachPhotoBox(scrolled.ScrolledPanel):
     def returnSIT(self):
         SITList = []
         for x in range(len(self.addrList)):
-            if self.typeList[x].GetValue() == "SIT" and self.addrList[x].GetValue() != "":
+            if self.typeList[x].GetValue() == "Site" and self.addrList[x].GetValue() != "":
                 SITList.append(self.addrList[x].GetValue())
         return SITList
 
     def returnSTR(self):
         STRList = []
         for x in range(len(self.addrList)):
-            if self.typeList[x].GetValue() == "STR" and self.addrList[x].GetValue() != "":
+            if self.typeList[x].GetValue() == "Structures, Site Facilities" and self.addrList[x].GetValue() != "":
                 STRList.append(self.addrList[x].GetValue())
         return STRList
 
     def returnCOL(self):
         COLList = []
         for x in range(len(self.addrList)):
-            if self.typeList[x].GetValue() == "COL" and self.addrList[x].GetValue() != "":
+            if self.typeList[x].GetValue() == "Control Conditions" and self.addrList[x].GetValue() != "":
                 COLList.append(self.addrList[x].GetValue())
         return COLList
 
     def returnCBL(self):
         CBLList = []
         for x in range(len(self.addrList)):
-            if self.typeList[x].GetValue() == "CBL" and self.addrList[x].GetValue() != "":
+            if self.typeList[x].GetValue() == "Cableway" and self.addrList[x].GetValue() != "":
                 CBLList.append(self.addrList[x].GetValue())
         return CBLList
 
     def returnEQP(self):
         EQPList = []
         for x in range(len(self.addrList)):
-            if self.typeList[x].GetValue() == "EQP" and self.addrList[x].GetValue() != "":
+            if self.typeList[x].GetValue() == "Device" and self.addrList[x].GetValue() != "":
                 EQPList.append(self.addrList[x].GetValue())
         return EQPList
 
     def returnCDT(self):
         CDTList = []
         for x in range(len(self.addrList)):
-            if self.typeList[x].GetValue() == "CDT" and self.addrList[x].GetValue() != "":
+            if self.typeList[x].GetValue() == "Device Conditions" and self.addrList[x].GetValue() != "":
                 CDTList.append(self.addrList[x].GetValue())
         return CDTList
 
     def returnHSN(self):
         HSNList = []
         for x in range(len(self.addrList)):
-            if self.typeList[x].GetValue() == "HSN" and self.addrList[x].GetValue() != "":
+            if self.typeList[x].GetValue() == "Hydrometric Survey Note" and self.addrList[x].GetValue() != "":
                 HSNList.append(self.addrList[x].GetValue())
         return HSNList
 

--- a/AttachmentPanel.py
+++ b/AttachmentPanel.py
@@ -57,14 +57,6 @@ class AttachmentPanel(wx.Panel):
         self.createConfirm = "Are you sure you want to save the FV Package to the FV PACKAGE SAVE LOCATION?"
         self.fm = "%Y%m%d"
         self.zipPath = ""
-        self.legendHeader = "Photos and Drawings: "
-        self.legend = "SIT - Site (general view of the monitoring area)\n" \
-                      "STR - Structures, Site Facilities (includes construction)\n" \
-                      "COL - Control Conditions (view of channel)\n" \
-                      "CBL - Cableway\n" \
-                      "EQP - Device (general view of monitoring equipment deployed)\n" \
-                      "CDT - Device Conditions (includes details for vandalism)\n" \
-                      "HSN - Hydrometric Survey Note"
         self.InitUI()
 
     def InitUI(self):
@@ -111,9 +103,6 @@ class AttachmentPanel(wx.Panel):
         self.zipper = wx.Button(self, label="CREATE FV PACKAGE")
         self.zipper.Bind(wx.EVT_BUTTON, self.Zip)
 
-        legendHeader = wx.StaticText(self, label=self.legendHeader)
-        legend = wx.StaticText(self, label=self.legend)
-
         sizerList[0].Add(self.indent)
         sizerList[0].Add(Txt1, 1, wx.EXPAND | wx.ALL, 5)
         sizerList[0].Add(self.attachBox1)
@@ -153,18 +142,10 @@ class AttachmentPanel(wx.Panel):
         sizerList[9].Add(self.zipSpace)
         sizerList[9].Add(self.zipper)
 
-        sizerList[10].Add(self.indent2)
-        sizerList[10].Add(legendHeader)
-
-        sizerList[11].Add(self.indent2)
-        sizerList[11].Add(self.indent3)
-        sizerList[11].Add(legend)
         self.layout.Add(TitlePanel, 0, wx.EXPAND | wx.ALL, 3)
         for i in range(10):
             self.layout.Add(spaceList[i])
             self.layout.Add(sizerList[i])
-        self.layout.Add(sizerList[10])
-        self.layout.Add(sizerList[11])
 
     def BrowseZipLoc(self, evt):
         DirOpenDialog = wx.DirDialog(self, self.zipTitle, self.rootPath,

--- a/ElectronicFieldNotesGUI.py
+++ b/ElectronicFieldNotesGUI.py
@@ -767,9 +767,7 @@ Note: The FlowTracker2 date and time is stored as UTC along with an offset for l
 
         defaultName = "AutoSave.xml"
         if self.manager is not None:
-            date = datetime.datetime.strptime(str(self.manager.genInfoManager.datePicker), self.manager.DT_FORMAT)
-            date = date.strftime("%Y%m%d")
-            defaultName = str(self.manager.genInfoManager.stnNumCmbo) + "_" + str(date) + "_FV.xml"
+            defaultName = str(self.manager.genInfoManager.stnNumCmbo) + "_" + str(self.manager.genInfoManager.datePicker).replace('/', '') + "_FV.xml"
         folder = "c:\\temp\\eHSN\\"
         name = folder + defaultName
         if not os.path.isdir(folder):

--- a/ElectronicFieldNotesGUI.py
+++ b/ElectronicFieldNotesGUI.py
@@ -101,6 +101,8 @@ ID_FILE_SAVE_EXIT = wx.NewId()
 ID_IMPORT_EHSN = wx.NewId()
 # ID_TOOLS_DRAW = wx.NewId()
 
+ID_FV_PACKAGE = wx.NewId()
+
 
 eHSN_WINDOW_SIZE = (500, 400)
 
@@ -249,6 +251,9 @@ class EHSNGui(wx.Frame):
         self.iFt2Desc = "Import FlowTracker2 (*.ft)"
         self.iEhsnLabel = "Merge eHSN Midsection (*.xml)"
         self.iEhsnDesc = "Merge eHSN Midsection (*.xml)"
+
+        self.FVpackLabel = "Create Field Visit Package"
+        self.FVpackDesc = "Create a ZIP file with eHSN XML and PDF, along with all files in the attachment tab (if there are any), for Aquarius Field Visit Upload."
 
         self.fullStyleSheetFileName = 'WSC_EHSN.xsml'
         self.summStyleSheetFileName = 'WSC_EHSN_Summary.xsml'
@@ -455,6 +460,8 @@ Note: The FlowTracker2 date and time is stored as UTC along with an offset for l
         fileMenu.AppendSeparator()
         faqu = fileMenu.Append(ID_FILE_EXPORT_AQUARIUS, self.fAquLabel, self.fAquDesc)
         fileMenu.AppendSeparator()
+        fvpack = fileMenu.Append(ID_FV_PACKAGE, self.FVpackLabel, self.FVpackDesc)
+        fileMenu.AppendSeparator()
         # fsexit = fileMenu.Append(ID_FILE_SAVE_EXIT, self.fSaveExitLabel, self.fSaveExitDesc)
         fsexit = fileMenu.Append(wx.MenuItem(fileMenu, ID_FILE_SAVE_EXIT, self.fSaveExitLabel, self.fSaveExitDesc))
         fexit = wx.MenuItem(fileMenu, ID_FILE_EXIT, self.fExitLabel, self.fExitDesc)
@@ -592,6 +599,9 @@ Note: The FlowTracker2 date and time is stored as UTC along with an offset for l
         # self.IniSaveAsPath()
         self.IniUploadSavePath()
         self.CreateFrames()
+
+        # Has to come after CreateFrames() otherwise self.attachment.Zip won't be accessable
+        self.Bind(wx.EVT_MENU, self.attachment.Zip, fvpack)
 
 
 

--- a/WaterLevelTablePanel.py
+++ b/WaterLevelTablePanel.py
@@ -180,7 +180,7 @@ class WaterLevelTablePanel(scrolled.ScrolledPanel):
         self.columnList[-1].Add(self.establishSizer[-1], 1, wx.EXPAND)
         self.columnList[-1].Add(self.descList[-1])
 
-        self.tableSizer.Add(self.columnList[-1])
+        self.tableSizer.Add(self.columnList[-1], 0, wx.EXPAND)
         self.layoutSizer.Layout()
         self.Update()
         if self.refresh:


### PR DESCRIPTION
Using the Python datetime method in ElectronicFieldNotesGUI.py was causing an error related to an unknown locale (en-GB). Since the datetime method was only used to get the date in "YYmmdd", and a similar date string is stored in self.manager.genInfoManager.datePicker, the datetime code has now been removed and replaced with string manipulation.

The Photos and Drawings legend present in the FV Package tab has been entirely removed (specifically removed from AttachmentPanel.py), and the dropdown for Photos and Drawings now contains the text values from the legend instead of the abbreviations (all changes in AttachPhotoBox.py).

The Zip() function that is called using the CREATE FV PACKAGE button in the FV Package tab has now been included in the File dropdown in the application header. This new menu option calls the Zip() function from the AttachmentPanel that is initialized within the CreateFrames() method, and therefore the function call for the menu must be bound after the CreateFrames() method is run (in ElectronicFieldNotesGUI.py).

The dynamic resizing of the table columns in the Level Notes tab has been improved so that the column widths for the rows now match the column widths for the table header. This fix required the horizontal BoxSizer that contains a given row of the table to be set as expandable when it is added to the vertical BoxSizer that represents the table itself (in WaterLevelTablePanel.py).